### PR TITLE
Updated models with references - bookings and instruments

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,4 +1,5 @@
 class Booking < ApplicationRecord
   belongs_to :user
+  belongs_to :instrument
   validates :start_date, presence: true
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,2 +1,4 @@
 class Instrument < ApplicationRecord
+  belongs_to :user_id
+  has_many :bookings
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :bookings
+  has_many :instruments
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/db/migrate/20230812165713_create_instruments.rb
+++ b/db/migrate/20230812165713_create_instruments.rb
@@ -7,7 +7,7 @@ class CreateInstruments < ActiveRecord::Migration[7.0]
       t.string :description
       t.integer :price
       t.string :location
-
+      t.references :user, null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20230815184549_create_bookings.rb
+++ b/db/migrate/20230815184549_create_bookings.rb
@@ -5,7 +5,7 @@ class CreateBookings < ActiveRecord::Migration[7.0]
       t.datetime :end_date
       t.boolean :confirmed
       t.references :user, null: false, foreign_key: true
-
+      t.references :instrument, null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_12_165713) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "instruments", force: :cascade do |t|
-    t.string "name"
-    t.string "type"
-    t.string "genre"
-    t.string "description"
-    t.integer "price"
-    t.string "location"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
 ActiveRecord::Schema[7.0].define(version: 2023_08_15_184549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,9 +19,24 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_184549) do
     t.datetime "end_date"
     t.boolean "confirmed"
     t.bigint "user_id", null: false
+    t.bigint "instrument_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["instrument_id"], name: "index_bookings_on_instrument_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
+  end
+
+  create_table "instruments", force: :cascade do |t|
+    t.string "name"
+    t.string "type"
+    t.string "genre"
+    t.string "description"
+    t.integer "price"
+    t.string "location"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_instruments_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -49,5 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_184549) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookings", "instruments"
   add_foreign_key "bookings", "users"
+  add_foreign_key "instruments", "users"
 end


### PR DESCRIPTION
Migrations added to update references. Models changed to allow for references.

To update schema locally once pulled from main, @rcavalcante11 & @davidavidavidavidavidave need to run in terminal:

rails db:drop db:create db:migrate